### PR TITLE
Add URL helper functions and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "techhandbook",
+  "version": "1.0.0",
+  "description": "--- cover: >-   https://images.unsplash.com/photo-1528605248644-14dd04022da1?crop=entropy&cs=tinysrgb&fm=jpg&ixid=MnwxOTcwMjR8MHwxfHNlYXJjaHwxMHx8dGVhbSUyMG9mJTIwcGVvcGxlfGVufDB8fHx8MTY2MDMxNzQzNg&ixlib=rb-1.2.1&q=80 coverY: 0 ---",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/urlHelpers.js
+++ b/src/urlHelpers.js
@@ -1,0 +1,15 @@
+const BASE_PATH = '/tech-leadership';
+
+function ensureTrailingSlash(str) {
+  return str.endsWith('/') ? str : str + '/';
+}
+
+function getWikiUrl(slug) {
+  return `${BASE_PATH}/wiki/${ensureTrailingSlash(slug)}`;
+}
+
+function getBlogUrl(slug) {
+  return `${BASE_PATH}/blog/${ensureTrailingSlash(slug)}`;
+}
+
+module.exports = { getWikiUrl, getBlogUrl };

--- a/tests/url.test.js
+++ b/tests/url.test.js
@@ -1,0 +1,11 @@
+const { getWikiUrl, getBlogUrl } = require('../src/urlHelpers.js');
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+test('creates wiki URLs with base path', () => {
+  assert.strictEqual(getWikiUrl('foo'), '/tech-leadership/wiki/foo/');
+});
+
+test('creates blog URLs with base path', () => {
+  assert.strictEqual(getBlogUrl('bar'), '/tech-leadership/blog/bar/');
+});


### PR DESCRIPTION
## Summary
- add `getWikiUrl` and `getBlogUrl` helpers
- create tests for URL helpers using Node's built-in test runner
- update `package.json` to run tests

## Testing
- `npm test`